### PR TITLE
Directive to search parent for leaflet directive

### DIFF
--- a/dist/ui-leaflet-draw.js
+++ b/dist/ui-leaflet-draw.js
@@ -3,7 +3,7 @@
  *
  * @version: 0.0.5
  * @author: Nicholas McCready
- * @date: Thu Mar 30 2017 23:48:17 GMT+0800 (SGT)
+ * @date: Thu Mar 30 2017 23:52:35 GMT+0800 (SGT)
  * @license: MIT
  */
 

--- a/dist/ui-leaflet-draw.js
+++ b/dist/ui-leaflet-draw.js
@@ -3,7 +3,7 @@
  *
  * @version: 0.0.5
  * @author: Nicholas McCready
- * @date: Thu Mar 30 2017 23:52:35 GMT+0800 (SGT)
+ * @date: Fri Jun 30 2017 20:28:47 GMT+0800 (+08)
  * @license: MIT
  */
 
@@ -67,16 +67,18 @@
         restrict: 'A',
         scope: false,
         replace: false,
-        require: ['^leaflet'],
-        controller: function($scope) {
-          this._deferredDrawTool = $q.defer();
-          this.getDrawTool = function() {
-            return this._deferredDrawTool.promise;
-          };
-          return this.getScope = function() {
-            return $scope;
-          };
-        },
+        require: ['leaflet'],
+        controller: [
+          '$scope', function($scope) {
+            this._deferredDrawTool = $q.defer();
+            this.getDrawTool = function() {
+              return this._deferredDrawTool.promise;
+            };
+            return this.getScope = function() {
+              return $scope;
+            };
+          }
+        ],
         link: function(scope, element, attrs, controller) {
           var _deferred, _featureGroup, _optionsEditedInDirective, leafletScope, mapController;
           mapController = controller[0];

--- a/dist/ui-leaflet-draw.js
+++ b/dist/ui-leaflet-draw.js
@@ -3,7 +3,7 @@
  *
  * @version: 0.0.5
  * @author: Nicholas McCready
- * @date: Sat Mar 18 2017 16:04:33 GMT-0400 (EDT)
+ * @date: Thu Mar 30 2017 23:48:17 GMT+0800 (SGT)
  * @license: MIT
  */
 
@@ -67,7 +67,7 @@
         restrict: 'A',
         scope: false,
         replace: false,
-        require: ['leaflet'],
+        require: ['^leaflet'],
         controller: function($scope) {
           this._deferredDrawTool = $q.defer();
           this.getDrawTool = function() {


### PR DESCRIPTION
I'm experimenting with separation of concerns using nested components within the leaflet directive. And I was thinking there is no real limitation on why we shouldn't allow ui-leaflet-draw to still work within the nested components. Is this okay?