### PR TITLE
Adding explicit DI injection to allow support for ng-strict-di

### DIFF
--- a/src/drawDirective.coffee
+++ b/src/drawDirective.coffee
@@ -25,12 +25,12 @@ angular.module('ui-leaflet')
     scope: false
     replace: false
     require: ['leaflet']
-    controller: ($scope) ->
+    controller: ['$scope', ($scope) ->
       @_deferredDrawTool = $q.defer()
       @getDrawTool = ->
         @_deferredDrawTool.promise
       @getScope = ->
-        $scope
+        $scope]
 
     link: (scope, element, attrs, controller) ->
       mapController = controller[0]


### PR DESCRIPTION
I only just noticed this change was contained in https://github.com/angular-ui/ui-leaflet-draw/pull/18. So don't mind where it comes from, but it is required if you use ng-strict-di mode. Incidentally, if you used ng-strict-di in your html head it should be a way of testing/replicating issue (alternative to what was done here: https://github.com/tomsaleeba/ui-leaflet-draw/tree/issue-8-tester/minification-test).